### PR TITLE
Fix hcs plugin spacing issues

### DIFF
--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -697,13 +697,13 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
       double x;
       double y;
       if (cols > 1) {
-         x = -cols * ySpacing_ / 2.0 + ySpacing_ * col + ySpacing_ / 2.0;
+         x = -cols * xSpacing_ / 2.0 + xSpacing_ * col + xSpacing_ / 2.0;
       } else {
          x = 0.0;
       }
 
       if (rows > 1) {
-         y = -rows * xSpacing_ / 2.0 + xSpacing_ * row + xSpacing_ / 2.0;
+         y = -rows * ySpacing_ / 2.0 + ySpacing_ * row + ySpacing_ / 2.0;
       } else {
          y = 0.0;
       }

--- a/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
+++ b/plugins/HCS/src/main/java/org/micromanager/hcs/SiteGenerator.java
@@ -697,13 +697,13 @@ public class SiteGenerator extends JFrame implements ParentPlateGUI {
       double x;
       double y;
       if (cols > 1) {
-         x = -cols * xSpacing_ / 2.0 + xSpacing_ * col + xSpacing_ / 2.0;
+         x = -cols * ySpacing_ / 2.0 + ySpacing_ * col + ySpacing_ / 2.0;
       } else {
          x = 0.0;
       }
 
       if (rows > 1) {
-         y = -rows * ySpacing_ / 2.0 + ySpacing_ * row + ySpacing_ / 2.0;
+         y = -rows * xSpacing_ / 2.0 + xSpacing_ * row + xSpacing_ / 2.0;
       } else {
          y = 0.0;
       }


### PR DESCRIPTION
The recent change in the hcs plugin introduced where the generation of an x position was based off the y position spacing and vice versa, resulting in incorrect in-well position. This PR reverts the behaviour to its previous state.